### PR TITLE
Start candle animation by long touch from standby

### DIFF
--- a/src/floower-esp32/automaton.cpp
+++ b/src/floower-esp32/automaton.cpp
@@ -69,7 +69,7 @@ void Automaton::onLeafTouch(FloowerTouchEvent event) {
           // close
           floower->setPetalsOpenLevel(0, 5000);
         }
-        else if (state == STATE_RUNNING) {
+        else if (state == STATE_RUNNING || state == STATE_CANDLE) {
           // shutdown
           floower->setColor(colorBlack, FloowerColorMode::TRANSITION, 2000);
           changeState(STATE_STANDBY);  
@@ -78,8 +78,14 @@ void Automaton::onLeafTouch(FloowerTouchEvent event) {
       break;
 
     case TOUCH_LONG:
-      floower->startAnimation(FloowerColorAnimation::RAINBOW);
-      changeState(STATE_RAINBOW);
+      if (state == STATE_STANDBY) {
+        floower->startAnimation(FloowerColorAnimation::CANDLE);
+        changeState(STATE_CANDLE);
+      }
+      else {
+        floower->startAnimation(FloowerColorAnimation::RAINBOW);
+        changeState(STATE_RAINBOW);
+      }
       disabledTouchUp = true;
       break;
 


### PR DESCRIPTION
This is more a feature request than a pull request.

BLE remote control is a very nice feature, but in daily use, the leaf is faster and more convenient. As we like the new candle animation very much, it would be nice to start the Floower in candle mode by just touching the leaf.

The pull request shows one (actually tested and used) way to activate the candle by a long touch from standby, but in exchange for the rainbow color picker. It would be nice to see an option to activate the candle by touch in the next release 😄 