### PR TITLE
Better WiFi and Floud connection reliability, reduced amount of communication

### DIFF
--- a/platformio/floower/src/behavior/SmartPowerBehavior.h
+++ b/platformio/floower/src/behavior/SmartPowerBehavior.h
@@ -51,6 +51,7 @@ class SmartPowerBehavior : public Behavior {
         unsigned long colorsUsed = 0; // used by nextRandomColor
 
         unsigned long watchDogsTime = 0;
+        unsigned long updateStatusTime = 0;
         unsigned long bluetoothStartTime = 0;
         unsigned long wifiStartTime = 0;
         unsigned long deepSleepTime = 0;


### PR DESCRIPTION
Wthout these changes I had a lot of problems with Floower constantly loosing connection to Floud and/or WiFi, caused by a couple of things:

* the heartbeat requests / messages (through `updateStatusData`) were sent quite often (each 1s), which was actually lower than `SOCKET_RESPONSE_TIMEOUT_MS` leading to a reset of the value for timeout detection leading to the timeout never being detected
  * increased to 15 seconds
  * increased socket timeout to 3 seconds for slower connections
* fixing the above bug led to a discovery that `updateStatusData` and `updateFloowerState` requests / messages actually never get any response from the server ... but this response was being used to detect timeouts!
  * changed `sendRequest` to `sendMessage` in those two methods
  * added `AsyncClient onTimeout` handler with `socketReconnect()` to detect timeouts even for those one-way communications
* it's better to send data out at once with `send()` and before that construct them with multiple `add(...)` calls instead of using `write(...)` which can lead to fragmented packets
* added and fixed some logging

Still the data receiving and parsing code contains (or at least I think) an error that would manifest when the incoming packets get fragmented. I did not have time to fix it.

But with those changes I'm running Floower 24x7 and it never disconnected from WiFi and also from Floud. I would know because it has become a welcoming beacon for me, my family and our visitors entering our flat, controlled by custom Home Assistant "integration" (sort of) through Floud. And it's fu...ng awesome!